### PR TITLE
Fix missing travis file error

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -84,6 +84,6 @@ sed \
     -e "s/{UNAME}/$UNAME/" \
     -e "s/{VERSION}/$VERSION/" \
     -e "s/{YEAR}/$YEAR/" \
-    -i setup.php hook.php $LNAME.xml tools/HEADER README.md .travis.yml
+    -i setup.php hook.php $LNAME.xml tools/HEADER README.md
 
 popd > /dev/null


### PR DESCRIPTION
After using `plugin.sh`, I always get the following error: 
`sed: can't read .travis.yml: No such file or directory`

Seems like this is a reference to and old file which is no longer part of the template.