### PR TITLE
fix: replace Bash-specific lowercase/uppercase substitution with portable tr command

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -44,8 +44,8 @@ else
 fi
 
 NAME=$(echo $1|tr -dc '[[:alpha:]]')
-LNAME=${NAME,,}
-UNAME=${NAME^^}
+LNAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]')
+UNAME=$(echo "$NAME" | tr '[:lower:]' '[:upper:]')
 VERSION=$2
 YEAR=$(date +%Y)
 


### PR DESCRIPTION
This change replaces the Bash-specific ${VAR,,} and ${VAR^^} syntax with a portable tr command. The original syntax is not supported by the default shell on macOS (which uses older versions of Bash or defaults to sh), causing the script to fail. Using tr ensures compatibility across Unix-like systems, including macOS.