### PR TITLE
Adapt template to GLPI 11.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
     name: "Generate CI matrix"
     uses: "glpi-project/plugin-ci-workflows/.github/workflows/generate-ci-matrix.yml@v1"
     with:
-      glpi-version: "10.0.x"
+      glpi-version: "11.0.x"
   ci:
     name: "GLPI ${{ matrix.glpi-version }} - php:${{ matrix.php-version }} - ${{ matrix.db-image }}"
     needs: "generate-ci-matrix"

--- a/.github/workflows/continuous-integration.yml.tpl
+++ b/.github/workflows/continuous-integration.yml.tpl
@@ -20,7 +20,7 @@ jobs:
     name: "Generate CI matrix"
     uses: "glpi-project/plugin-ci-workflows/.github/workflows/generate-ci-matrix.yml@v1"
     with:
-      glpi-version: "10.0.x"
+      glpi-version: "11.0.x"
   ci:
     name: "GLPI ${{ matrix.glpi-version }} - php:${{ matrix.php-version }} - ${{ matrix.db-image }}"
     needs: "generate-ci-matrix"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.2"
     },
     "require-dev": {
         "glpi-project/tools": "^0.7"
@@ -8,7 +8,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "7.4.0"
+            "php": "8.2.99"
         },
         "sort-packages": true
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,7 @@
 includes:
+    - ../../vendor/glpi-project/phpstan-glpi/extension.neon
     - ../../vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - ../../vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
 
 parameters:
     level: max
@@ -10,7 +12,6 @@ parameters:
     scanDirectories:
         - ../../src
     bootstrapFiles:
-        - ../../inc/based_config.php
-    stubFiles:
         - ../../stubs/glpi_constants.php
+        - ../../vendor/autoload.php
     treatPhpDocTypesAsCertain: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,9 @@
-<phpunit bootstrap="tests/bootstrap.php" colors="true" testdox="true">
+<phpunit
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    testdox="true"
+    cacheDirectory="var/phpunit"
+>
     <testsuites>
         <testsuite name="Tests">
             <directory suffix="Test.php">tests</directory>

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,9 +29,7 @@
       <version>
          <num>{VERSION}</num>
          <!-- Add as many compatibility tag you want -->
-         <compatibility>9.4</compatibility>
-         <compatibility>9.3</compatibility>
-         <compatibility>9.2</compatibility>
+         <compatibility>~11.0.0</compatibility>
       </version>
    </versions>
    <langs>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<psalm
+    runTaintAnalysis="true"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <file name="hook.php"/>
+        <file name="setup.php"/>
+    </projectFiles>
+</psalm>

--- a/setup.php.tpl
+++ b/setup.php.tpl
@@ -31,25 +31,22 @@
  * -------------------------------------------------------------------------
  */
 
+/** @phpstan-ignore theCodingMachineSafe.function (safe to assume this isn't already defined) */
 define('PLUGIN_{UNAME}_VERSION', '{VERSION}');
 
 // Minimal GLPI version, inclusive
-define("PLUGIN_{UNAME}_MIN_GLPI_VERSION", "10.0.0");
+/** @phpstan-ignore theCodingMachineSafe.function (safe to assume this isn't already defined) */
+define("PLUGIN_{UNAME}_MIN_GLPI_VERSION", "11.0.0");
 
 // Maximum GLPI version, exclusive
-define("PLUGIN_{UNAME}_MAX_GLPI_VERSION", "10.0.99");
+/** @phpstan-ignore theCodingMachineSafe.function (safe to assume this isn't already defined) */
+define("PLUGIN_{UNAME}_MAX_GLPI_VERSION", "11.0.99");
 
 /**
  * Init hooks of the plugin.
  * REQUIRED
  */
-function plugin_init_{LNAME}(): void
-{
-    /** @var array<string, array<string, mixed>> $PLUGIN_HOOKS */
-    global $PLUGIN_HOOKS;
-
-    $PLUGIN_HOOKS['csrf_compliant']['{LNAME}'] = true;
-}
+function plugin_init_{LNAME}(): void {}
 
 /**
  * Get the name and the version of the plugin

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,16 +31,7 @@
  * -------------------------------------------------------------------------
  */
 
-global $CFG_GLPI, $PLUGIN_HOOKS;
-
-define('GLPI_ROOT', __DIR__ . '/../../../');
-define('GLPI_LOG_DIR', __DIR__ . '/files/_logs');
-
-define('TU_USER', 'glpi');
-define('TU_PASS', 'glpi');
-define('GLPI_LOG_LVL', 'DEBUG');
-
-require GLPI_ROOT . '/inc/includes.php';
+require __DIR__ . '/../../../phpunit/bootstrap.php';
 
 if (!Plugin::isPluginActive("{LNAME}")) {
     throw new RuntimeException("Plugin {LNAME} is not active in the test database");


### PR DESCRIPTION
- Use same PHP requirements as GLPI 11.0.
- Remove usage of `$PLUGIN_HOOKS['csrf_compliant']`.
- Enable `glpi-project/phpstan-glpi` and `/thecodingmachine/phpstan-safe-rule` PHPStan extensions provided by GLPI.
- Add Psalm configuration for taint analysis.
- Adapt the PHPUnit configuration/bootstrap.