### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Ensure GitHub Actions are used in their latest version
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  # Strategy for composer dependencies
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "direct"
+    open-pull-requests-limit: 100
+    versioning-strategy: "increase"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+
+  # Strategy for npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "direct"
+    open-pull-requests-limit: 100
+    versioning-strategy: "increase"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
Added Dependabot for `empty` and the plugin created (via rsync in `plugin.sh`).

_If the created plugin does not use NPM, the NPM check by Dependabot will simply be ignored (the same applies to Composer)._