### PR TITLE
chore: Add documentation on how to update the plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor/
 composer.lock
 *.min.*
 var
+/.vscode/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -38,13 +38,9 @@ we recommend using [_template-sync_](https://github.com/coopTilleuls/template-sy
 
 1. Run the script to synchronize your project with the latest version of the skeleton:
 
-   <!-- markdownlint-disable MD013 -->
-
    ```console
    curl -sSL https://raw.githubusercontent.com/coopTilleuls/template-sync/main/template-sync.sh | sh -s -- https://github.com/pluginsGLPI/empty
    ```
-
-   <!-- markdownlint-enable MD013 -->
 
 2. Resolve conflicts, if any
 3. Run `git cherry-pick --continue`

--- a/README.md
+++ b/README.md
@@ -30,3 +30,23 @@ You can also provide a destination path (ie. if your `empty` directory is not in
 * `{LNAME}` will be replaced byt the lowercased name,
 * `{UNAME}` will be replaced by the uppercased name,
 * `{YEAR}` will be replaced by the current year.
+
+## Updating Your Plugin
+
+To import the changes made to the _pluginsGLPI empty_ template into your project,
+we recommend using [_template-sync_](https://github.com/coopTilleuls/template-sync):
+
+1. Run the script to synchronize your project with the latest version of the skeleton:
+
+   <!-- markdownlint-disable MD013 -->
+
+   ```console
+   curl -sSL https://raw.githubusercontent.com/coopTilleuls/template-sync/main/template-sync.sh | sh -s -- https://github.com/pluginsGLPI/empty
+   ```
+
+   <!-- markdownlint-enable MD013 -->
+
+2. Resolve conflicts, if any
+3. Run `git cherry-pick --continue`
+
+For more advanced options, refer to [the documentation of _template sync_](https://github.com/coopTilleuls/template-sync#template-sync).


### PR DESCRIPTION
Since this repository is used by many plugin as template (as it's goal), I don't have the permission to edit it but we should declare it as a [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)

<img width="1678" height="473" alt="Screenshot from 2025-12-10 15-24-26" src="https://github.com/user-attachments/assets/c4e1d9a5-3966-499a-a6da-da9d7e5b7265" />

This PR update the README to also explain the user how he can then update his repo in the future when the template evolves.

This use the [template-sync](https://github.com/coopTilleuls/template-sync?tab=readme-ov-file#template-sync) script, [symfony-docker](https://github.com/dunglas/symfony-docker/blob/main/docs/updating.md) is using it for example