### PR TITLE
Remove glpi tools dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,16 @@
     "require": {
         "php": ">=8.2"
     },
-    "require-dev": {
-        "glpi-project/tools": "^0.8"
-    },
     "config": {
         "optimize-autoloader": true,
         "platform": {
             "php": "8.2.99"
         },
         "sort-packages": true
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "GlpiPlugin\\{NS_NAME}\\Tests\\": "tests/"
+        }
     }
 }

--- a/plugin.sh
+++ b/plugin.sh
@@ -48,6 +48,7 @@ fi
 NAME=$(echo $1|tr -dc '[[:alpha:]]')
 LNAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]')
 UNAME=$(echo "$NAME" | tr '[:lower:]' '[:upper:]')
+NS_NAME=$(echo "$1" | sed -E 's/\b([a-z])/\U\1/g' | tr -dc '[[:alpha:]]')
 VERSION=$2
 YEAR=$(date +%Y)
 
@@ -85,6 +86,7 @@ sed \
     -e "s/{NAME}/$NAME/g" \
     -e "s/{LNAME}/$LNAME/g" \
     -e "s/{UNAME}/$UNAME/g" \
+    -e "s/{NS_NAME}/$NS_NAME/g" \
     -e "s/{VERSION}/$VERSION/g" \
     -e "s/{YEAR}/$YEAR/g" \
     -i setup.php hook.php $LNAME.xml tools/HEADER README.md Makefile .github/workflows/continuous-integration.yml tests/bootstrap.php composer.json rector.php

--- a/plugin.sh
+++ b/plugin.sh
@@ -95,3 +95,5 @@ sed \
 sed -i '/^[[:space:]]*composer\.lock[[:space:]]*$/d' .gitignore
 
 popd > /dev/null
+
+echo -e "\033[0;32mPlugin $NAME created under $DEST\033[0m"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,8 +31,12 @@
  * -------------------------------------------------------------------------
  */
 
-require __DIR__ . '/../../../tests/bootstrap.php';
+$current_plugin_folder = basename(realpath(__DIR__ . '/../'));
 
-if (!Plugin::isPluginActive("{LNAME}")) {
-    throw new RuntimeException("Plugin {LNAME} is not active in the test database");
+require __DIR__ . '/../../../tests/bootstrap.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (!Plugin::isPluginActive($current_plugin_folder)) {
+	echo("Plugin $current_plugin_folder is not active in the test database" . PHP_EOL);
+	die();
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,9 +31,11 @@
  * -------------------------------------------------------------------------
  */
 
+$current_plugin_folder = basename(realpath(__DIR__ . '/../'));
+
 require __DIR__ . '/../../../tests/bootstrap.php';
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-if (!Plugin::isPluginActive("{LNAME}")) {
-	throw new RuntimeException("Plugin {LNAME} is not active in the test database");
+if (!Plugin::isPluginActive($current_plugin_folder)) {
+	throw new RuntimeException("Plugin $current_plugin_folder is not active in the test database");
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,12 +31,9 @@
  * -------------------------------------------------------------------------
  */
 
-$current_plugin_folder = basename(realpath(__DIR__ . '/../'));
-
 require __DIR__ . '/../../../tests/bootstrap.php';
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-if (!Plugin::isPluginActive($current_plugin_folder)) {
-	echo("Plugin $current_plugin_folder is not active in the test database" . PHP_EOL);
-	die();
+if (!Plugin::isPluginActive("{LNAME}")) {
+	throw new RuntimeException("Plugin {LNAME} is not active in the test database");
 }


### PR DESCRIPTION
GLPI tools is now natively inside GLPI 11 core, we can remove it's dependency.

Based on what was done on the whatsapp plugin, I've updated the autoload and test bootstrap.

Nightly images will run it and otherwise it will be available on GLPI 11.0.6

## Interconnected PR (merge order) :
- https://github.com/glpi-project/plugin-ci-workflows/pull/50
- https://github.com/glpi-project/glpi/pull/22465
- https://github.com/pluginsGLPI/empty/pull/57