### PR TITLE
Remove 'testdox' attribute from phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <phpunit
     bootstrap="tests/bootstrap.php"
     colors="true"
-    testdox="true"
     cacheDirectory="var/phpunit"
 >
     <source>


### PR DESCRIPTION
Reduce the very verbose output to the regular phpunit one

## From

<img width="754" height="1204" alt="image" src="https://github.com/user-attachments/assets/30800b64-ea3f-4eba-8c8c-a71978929a60" />

## To

<img width="754" height="325" alt="image" src="https://github.com/user-attachments/assets/6f3da98c-fbcb-470a-9887-337f60a6c646" />
